### PR TITLE
Use sdl-config and pkg-config to add compiler flags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ SRC=main.c apr.c mem.c tty.c
 #CFLAGS= -Wno-shift-op-parentheses -Wno-logical-op-parentheses \
 #        -Wno-bitwise-op-parentheses
 CFLAGS=  -fno-diagnostics-show-caret \
-        -L/usr/local/lib -I/usr/local/include -lSDL -lSDL_image -lpthread
+	`sdl-config --cflags` `pkg-config SDL_image --cflags`
+
+LIBS=	`sdl-config --libs` `pkg-config SDL_image --libs` -lpthread
 
 
 pdp6: $(SRC) pdp6.h
-	$(CC) $(CFLAGS) $(SRC) -o pdp6
+	$(CC) $(CFLAGS) $(SRC) $(LIBS) -o pdp6
 

--- a/main.c
+++ b/main.c
@@ -1,6 +1,6 @@
 #include "pdp6.h"
-#include <SDL/SDL.h>
-#include <SDL/SDL_image.h>
+#include <SDL.h>
+#include <SDL_image.h>
 #include <pthread.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
This replaces the hard-coded include paths in the Makefile with ones from `sdl-config` and `pkg-config`.