### PR TITLE
Add window titles.

### DIFF
--- a/emu/dis340.c
+++ b/emu/dis340.c
@@ -841,6 +841,7 @@ renderthread(void *arg)
 
 	if(SDL_CreateWindowAndRenderer(1024, 1024, 0, &window, &renderer) < 0)
 		err("SDL_CreateWindowAndRenderer() failed: %s\n", SDL_GetError());
+	SDL_SetWindowTitle(window, "Type 340 display");
 	tex = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
 		SDL_TEXTUREACCESS_STREAMING, 1024, 1024);
 	SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);

--- a/emu/main_panel.c
+++ b/emu/main_panel.c
@@ -1224,6 +1224,7 @@ void main340(void);
 
 	if(SDL_CreateWindowAndRenderer(1399, 740, 0, &window, &renderer) < 0)
 		err("SDL_CreateWindowAndRenderer() failed: %s\n", SDL_GetError());
+	SDL_SetWindowTitle(window, "PDP-6 console");
 
 	initpanel();
 	panelsynch.l = &panellock;


### PR DESCRIPTION
"Type 340 display", and  
"PDP-6 console".

I'm not 100% happy, because the latter is more than just the console.  Maybe "PDP-6 panels?"