### PR TITLE
Need unistd.h header file

### DIFF
--- a/emu/joy.c
+++ b/emu/joy.c
@@ -1,6 +1,7 @@
 #include "pdp6.h"
 #include <signal.h>
 #include <SDL2/SDL.h>
+#include <unistd.h>
 
 char *joy_ident = JOY_IDENT;
 char *ojoy_ident = OJOY_IDENT;


### PR DESCRIPTION
I am building on Fedora 40, and get compile errors from missing definitions.

Adding the unistd.h header file to emu/joy.c corrects this error.